### PR TITLE
ci: run checks only if pushing `main` branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Check - Test
 
 on:
   push:
+    branches: [ 'main' ]
   pull_request:
 
 jobs:


### PR DESCRIPTION
모든 PR은 검사하고, push는 main 브랜치에만 적용되도록 변경